### PR TITLE
feat: Improve Refresh functionality - implement --minimal flag

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,6 @@
 
 The current date is Thu, May 15, 2025.
 
-Claudes follows the instructions in this file to generate code. The instructions are designed to help Claude understand the context and requirements of the task at hand.
+Claude follows the instructions in this file to generate code. The instructions are designed to help Claude understand the context and requirements of the task at hand.
 
 For more info see the [CLAUDE.md](../CLAUDE.md) file.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,7 @@
 # n8n-cli Copilot Instructions
 
+The current date is Thu, May 15, 2025.
+
+Claudes follows the instructions in this file to generate code. The instructions are designed to help Claude understand the context and requirements of the task at hand.
+
 For more info see the [CLAUDE.md](../CLAUDE.md) file.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 dist
 *.out
+bin

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,59 +1,61 @@
 ---
 branches:
   - { name: main, prerelease: false, channel: latest }
-  - { name: "rc/*", prerelease: rc, channel: rc }
+  - { name: 'rc/*', prerelease: rc, channel: rc }
 verifyConditions:
-  - "@semantic-release/github"
-  - "@semantic-release/git"
+  - '@semantic-release/github'
+  - '@semantic-release/git'
 
 plugins:
-  - - "@semantic-release/commit-analyzer"
-    - preset: "conventionalcommits"
+  - - '@semantic-release/commit-analyzer'
+    - preset: 'conventionalcommits'
       releaseRules:
-        - { type: "feat", release: "minor" }
-        - { type: "impr", release: "patch" }
-        - { type: "refactor", release: "patch" }
-        - { type: "perf", release: "patch" }
-        - { type: "fix", release: "patch" }
-        - { type: "ci", release: "patch" }
-        - { type: "docs", release: "patch" }
-        - { type: "style", release: "patch" }
-        - { type: "test", release: "patch" }
-        - { type: "build", release: "patch" }
-        - { type: "chore", release: "patch", scope: "!release" }
+        - { type: 'feat', release: 'minor' }
+        - { type: 'impr', release: 'patch' }
+        - { type: 'refactor', release: 'patch' }
+        - { type: 'perf', release: 'patch' }
+        - { type: 'fix', release: 'patch' }
+        - { type: 'ci', release: 'patch' }
+        - { type: 'docs', release: 'patch' }
+        - { type: 'style', release: 'patch' }
+        - { type: 'test', release: 'patch' }
+        - { type: 'build', release: 'patch' }
+        - { type: 'ai', release: 'patch' }
+        - { type: 'chore', release: 'patch', scope: '!release' }
 
-  - - "@semantic-release/release-notes-generator"
-    - preset: "conventionalcommits"
+  - - '@semantic-release/release-notes-generator'
+    - preset: 'conventionalcommits'
       presetConfig:
         types:
-          - { type: "feat", section: "✨ Features" }
-          - { type: "impr", section: "🚀 Improvements" }
-          - { type: "refactor", section: "♻️ Improvements" }
-          - { type: "perf", section: "⚡️ Improvements" }
-          - { type: "fix", section: "🐛 Bug Fixes" }
-          - { type: "ci", section: "👷 CI" }
-          - { type: "docs", section: "📚 Documentation" }
-          - { type: "chore", section: "🔧 Miscellaneous" }
-          - { type: "style", section: "🎨 Miscellaneous" }
-          - { type: "test", section: "✅ Miscellaneous" }
-          - { type: "build", section: "📦 Miscellaneous" }
+          - { type: 'feat', section: '✨ Features' }
+          - { type: 'impr', section: '🚀 Improvements' }
+          - { type: 'refactor', section: '♻️ Improvements' }
+          - { type: 'perf', section: '⚡️ Improvements' }
+          - { type: 'fix', section: '🐛 Bug Fixes' }
+          - { type: 'ci', section: '👷 CI' }
+          - { type: 'docs', section: '📚 Documentation' }
+          - { type: 'chore', section: '🔧 Miscellaneous' }
+          - { type: 'style', section: '🎨 Miscellaneous' }
+          - { type: 'test', section: '✅ Miscellaneous' }
+          - { type: 'build', section: '📦 Miscellaneous' }
+          - { type: 'ai', section: '🤖 Artificial Intelligence' }
 
-  - - "@semantic-release/changelog"
+  - - '@semantic-release/changelog'
     - changelogFile: CHANGELOG.md
       changelogTitle: "# Changelog\n\nAll notable changes to this project will be documented in this file."
       verifyConditions: true
 
-  - - "@semantic-release/github"
+  - - '@semantic-release/github'
     - assets:
         - CHANGELOG.md
-      releasedLabels: ["released"]
-      releaseNameTemplate: "🚀 Version ${nextRelease.version}"
-      successCommentCondition: "false"
+      releasedLabels: ['released']
+      releaseNameTemplate: '🚀 Version ${nextRelease.version}'
+      successCommentCondition: 'false'
 
-  - - "@semantic-release/git"
+  - - '@semantic-release/git'
     - assets:
         - CHANGELOG.md
       message: "chore(release): 🔖 ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
 
-repositoryUrl: "https://github.com/edenreich/n8n-cli"
-tagFormat: "v${version}"
+repositoryUrl: 'https://github.com/edenreich/n8n-cli'
+tagFormat: 'v${version}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,10 @@ You have the following tools available for development:
 1. Start by writing unit tests for your new features or commands (Using Test-driven development).
 2. Always review `Taskfile.yaml` for available development tasks.
 3. Always use existing types from n8n for consistency.
-4. Use `task cli -- <args>` to run the CLI during development.
-5. Always run `task lint` to verify and fix code errors before proceeding with the build.
-6. Use `task build` to build the CLI with proper version information.
-7. Use Cobra-CLI to generate new commands: `cobra-cli add <command-name>`
-8. Always fetch the latest documentation using context7 and fall back to fetch.
-9. When adding new commands, make sure to properly handle flags and implement the Run function.
+4. Always prefer using early returns in your code to avoid deep nesting.
+5. Use `task cli -- <args>` to run the CLI during development.
+6. Always run `task lint` to verify and fix code errors before proceeding with the build.
+7. Use `task build` to build the CLI with proper version information.
+8. Use Cobra-CLI to generate new commands: `cobra-cli add <command-name>`
+9. Always fetch the latest documentation using context7 and fall back to fetch.
+10. When adding new commands, make sure to properly handle flags and implement the Run function.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Options:
 - `--dry-run`: Show what would be updated without making changes
 - `--overwrite`: Overwrite existing files even if they have a different name
 - `--output, -o`: Output format for new workflow files (json or yaml)
+- `--minimal`: Minimize workflow files by removing null and optional fields (default: true).
 
 Example:
 
@@ -164,6 +165,9 @@ n8n workflows refresh --directory workflows/ --dry-run
 
 # Refresh workflows and save them as YAML files
 n8n workflows refresh --directory workflows/ --output yaml
+
+# Refresh workflows without minimizing the JSON/YAML output
+n8n workflows refresh --directory workflows/ --minimal=false
 ```
 
 #### Sync

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -43,7 +43,7 @@ tasks:
   build:
     desc: 'Build the n8n CLI with version information'
     cmds:
-      - go build -ldflags="{{.LD_FLAGS}}" -o n8n main.go
+      - go build -ldflags="{{.LD_FLAGS}}" -o ./bin/n8n main.go
 
   test-unit:
     desc: 'Run only unit tests'

--- a/cmd/workflows/refresh.go
+++ b/cmd/workflows/refresh.go
@@ -183,7 +183,19 @@ func RefreshWorkflowsWithClient(cmd *cobra.Command, client n8n.ClientInterface, 
 			if _, fileErr := os.Stat(filePath); fileErr == nil {
 				existingContent, readErr := os.ReadFile(filePath)
 				if readErr == nil {
-					needsUpdate = string(existingContent) != string(content)
+					ext := strings.ToLower(filepath.Ext(filePath))
+					if ext == ".yaml" || ext == ".yml" {
+						var existingWorkflow, newWorkflow n8n.Workflow
+						if yamlErr := yaml.Unmarshal(existingContent, &existingWorkflow); yamlErr == nil {
+							if yamlErr := yaml.Unmarshal(content, &newWorkflow); yamlErr == nil {
+								existingJSON, _ := json.Marshal(existingWorkflow)
+								newJSON, _ := json.Marshal(newWorkflow)
+								needsUpdate = string(existingJSON) != string(newJSON)
+							}
+						}
+					} else {
+						needsUpdate = string(existingContent) != string(content)
+					}
 				}
 			}
 		}

--- a/cmd/workflows/refresh.go
+++ b/cmd/workflows/refresh.go
@@ -148,6 +148,10 @@ func cleanWorkflow(workflow n8n.Workflow) map[string]interface{} {
 	delete(workflowMap, "createdAt")
 	delete(workflowMap, "updatedAt")
 
+	if _, exists := workflowMap["connections"]; !exists {
+		workflowMap["connections"] = make(map[string]interface{})
+	}
+
 	return workflowMap
 }
 
@@ -261,6 +265,12 @@ func serializeWorkflow(workflow n8n.Workflow, filePath string, minimal bool) ([]
 	var workflowToSerialize interface{} = workflow
 	if minimal {
 		workflowToSerialize = cleanWorkflow(workflow)
+	} else {
+		if workflow.Connections == nil {
+			workflowCopy := workflow
+			workflowCopy.Connections = make(map[string]interface{})
+			workflowToSerialize = workflowCopy
+		}
 	}
 
 	ext := strings.ToLower(filepath.Ext(filePath))

--- a/cmd/workflows/refresh.go
+++ b/cmd/workflows/refresh.go
@@ -49,6 +49,7 @@ func init() {
 	refreshCmd.Flags().Bool("dry-run", false, "Show what would be updated without making changes")
 	refreshCmd.Flags().Bool("overwrite", false, "Overwrite existing files even if they have a different name")
 	refreshCmd.Flags().StringP("output", "o", "json", "Output format for new workflow files (json or yaml)")
+	refreshCmd.Flags().Bool("minimal", true, "Minimize workflow files by removing null and optional fields")
 	rootcmd.GetWorkflowsCmd().AddCommand(refreshCmd)
 
 	// nolint:errcheck
@@ -62,6 +63,7 @@ func RefreshWorkflows(cmd *cobra.Command, args []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	overwrite, _ := cmd.Flags().GetBool("overwrite")
 	output, _ := cmd.Flags().GetString("output")
+	minimal, _ := cmd.Flags().GetBool("minimal")
 
 	if directory == "" {
 		return fmt.Errorf("directory is required")
@@ -72,24 +74,13 @@ func RefreshWorkflows(cmd *cobra.Command, args []string) error {
 
 	client := n8n.NewClient(instanceURL, apiKey)
 
-	return RefreshWorkflowsWithClient(cmd, client, directory, dryRun, overwrite, output)
+	return RefreshWorkflowsWithClient(cmd, client, directory, dryRun, overwrite, output, minimal)
 }
 
 // RefreshWorkflowsWithClient is the testable version of RefreshWorkflows that accepts a client interface
-func RefreshWorkflowsWithClient(cmd *cobra.Command, client n8n.ClientInterface, directory string, dryRun bool, overwrite bool, output string) error {
-
-	_, err := os.Stat(directory)
-	if os.IsNotExist(err) {
-		if !dryRun {
-			if err := os.MkdirAll(directory, 0755); err != nil {
-				return fmt.Errorf("error creating directory: %w", err)
-			}
-			cmd.Printf("Created directory: %s\n", directory)
-		} else {
-			cmd.Printf("Would create directory: %s\n", directory)
-		}
-	} else if err != nil {
-		return fmt.Errorf("error accessing directory: %w", err)
+func RefreshWorkflowsWithClient(cmd *cobra.Command, client n8n.ClientInterface, directory string, dryRun bool, overwrite bool, output string, minimal bool) error {
+	if err := ensureDirectoryExists(cmd, directory, dryRun); err != nil {
+		return err
 	}
 
 	workflowList, err := client.GetWorkflows()
@@ -102,129 +93,342 @@ func RefreshWorkflowsWithClient(cmd *cobra.Command, client n8n.ClientInterface, 
 		return nil
 	}
 
-	localFiles := make(map[string]string)
-
-	files, err := os.ReadDir(directory)
-	if err == nil {
-		for _, file := range files {
-			if !file.IsDir() {
-				ext := strings.ToLower(filepath.Ext(file.Name()))
-				if ext == ".json" || ext == ".yaml" || ext == ".yml" {
-					filePath := filepath.Join(directory, file.Name())
-					if workflowID, err := ExtractWorkflowIDFromFile(filePath); err == nil && workflowID != "" {
-						localFiles[workflowID] = filePath
-					}
-				}
-			}
-		}
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("error reading directory: %w", err)
+	localFiles, err := extractLocalWorkflows(directory)
+	if err != nil {
+		return err
 	}
 
 	for _, workflow := range *workflowList.Data {
-		if workflow.Id == nil || *workflow.Id == "" {
-			cmd.Printf("Skipping workflow '%s' with no ID\n", workflow.Name)
-			continue
+		if err := processWorkflow(cmd, workflow, localFiles, directory, dryRun, overwrite, output, minimal); err != nil {
+			return err
 		}
-
-		sanitizedName := rootcmd.SanitizeFilename(workflow.Name)
-		var filePath string
-		var action string
-
-		var extension string
-		switch strings.ToLower(output) {
-		case "yaml", "yml":
-			extension = ".yaml"
-		default:
-			extension = ".json"
-		}
-
-		if existingPath, exists := localFiles[*workflow.Id]; exists && !overwrite {
-			existingExt := filepath.Ext(existingPath)
-			if (strings.ToLower(output) == "yaml" || strings.ToLower(output) == "yml") &&
-				(strings.ToLower(existingExt) == ".json") {
-				filePath = filepath.Join(directory, sanitizedName+extension)
-				action = "Converting"
-			} else if strings.ToLower(output) == "json" &&
-				(strings.ToLower(existingExt) == ".yaml" || strings.ToLower(existingExt) == ".yml") {
-				filePath = filepath.Join(directory, sanitizedName+extension)
-				action = "Converting"
-			} else {
-				filePath = existingPath
-				action = "Updating"
-			}
-		} else {
-			filePath = filepath.Join(directory, sanitizedName+extension)
-			action = "Creating"
-		}
-
-		var content []byte
-		var err error
-
-		switch strings.ToLower(filepath.Ext(filePath)) {
-		case ".yaml", ".yml":
-			var buf strings.Builder
-			encoder := yaml.NewEncoder(&buf)
-			encoder.SetIndent(2)
-			if err := encoder.Encode(workflow); err != nil {
-				return fmt.Errorf("error serializing workflow '%s' to YAML: %w", workflow.Name, err)
-			}
-			content = []byte(buf.String())
-		default:
-			content, err = json.MarshalIndent(workflow, "", "  ")
-			if err != nil {
-				return fmt.Errorf("error serializing workflow '%s' to JSON: %w", workflow.Name, err)
-			}
-		}
-
-		needsUpdate := true
-		if existingPath, exists := localFiles[*workflow.Id]; exists &&
-			strings.EqualFold(filepath.Ext(existingPath), filepath.Ext(filePath)) {
-			if _, fileErr := os.Stat(filePath); fileErr == nil {
-				existingContent, readErr := os.ReadFile(filePath)
-				if readErr == nil {
-					ext := strings.ToLower(filepath.Ext(filePath))
-					if ext == ".yaml" || ext == ".yml" {
-						var existingWorkflow, newWorkflow n8n.Workflow
-						if yamlErr := yaml.Unmarshal(existingContent, &existingWorkflow); yamlErr == nil {
-							if yamlErr := yaml.Unmarshal(content, &newWorkflow); yamlErr == nil {
-								existingJSON, _ := json.Marshal(existingWorkflow)
-								newJSON, _ := json.Marshal(newWorkflow)
-								needsUpdate = string(existingJSON) != string(newJSON)
-							}
-						}
-					} else {
-						needsUpdate = string(existingContent) != string(content)
-					}
-				}
-			}
-		}
-
-		if !needsUpdate && action == "Updating" {
-			cmd.Printf("No changes for workflow '%s' (ID: %s) in file: %s\n",
-				workflow.Name, *workflow.Id, filePath)
-			continue
-		}
-
-		if dryRun {
-			if needsUpdate || action == "Creating" || action == "Converting" {
-				cmd.Printf("Would %s workflow '%s' (ID: %s) to file: %s\n",
-					strings.ToLower(action), workflow.Name, *workflow.Id, filePath)
-			} else {
-				cmd.Printf("No changes needed for workflow '%s' (ID: %s) in file: %s\n",
-					workflow.Name, *workflow.Id, filePath)
-			}
-			continue
-		}
-
-		if err := os.WriteFile(filePath, content, 0644); err != nil {
-			return fmt.Errorf("error writing workflow '%s' to file: %w", workflow.Name, err)
-		}
-
-		cmd.Printf("%s workflow '%s' (ID: %s) to file: %s\n",
-			action, workflow.Name, *workflow.Id, filePath)
 	}
 
 	cmd.Println("Workflow refresh completed successfully")
+	return nil
+}
+
+// ensureDirectoryExists checks if the directory exists and creates it if needed
+func ensureDirectoryExists(cmd *cobra.Command, directory string, dryRun bool) error {
+	_, err := os.Stat(directory)
+	if os.IsNotExist(err) {
+		if dryRun {
+			cmd.Printf("Would create directory: %s\n", directory)
+			return nil
+		}
+
+		if err := os.MkdirAll(directory, 0755); err != nil {
+			return fmt.Errorf("error creating directory: %w", err)
+		}
+		cmd.Printf("Created directory: %s\n", directory)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error accessing directory: %w", err)
+	}
+
+	return nil
+}
+
+// cleanWorkflow removes all null and empty fields from a workflow structure
+func cleanWorkflow(workflow n8n.Workflow) map[string]interface{} {
+	workflowBytes, err := json.Marshal(workflow)
+	if err != nil {
+		return make(map[string]interface{})
+	}
+
+	var workflowMap map[string]interface{}
+	if err := json.Unmarshal(workflowBytes, &workflowMap); err != nil {
+		return make(map[string]interface{})
+	}
+
+	cleanMapRecursive(workflowMap)
+
+	delete(workflowMap, "createdAt")
+	delete(workflowMap, "updatedAt")
+
+	return workflowMap
+}
+
+// cleanMapRecursive removes all null values recursively from a map
+func cleanMapRecursive(m map[string]interface{}) {
+	for k, v := range m {
+		if v == nil {
+			delete(m, k)
+			continue
+		}
+
+		switch val := v.(type) {
+		case map[string]interface{}:
+			cleanMapRecursive(val)
+			if len(val) == 0 {
+				delete(m, k)
+			}
+		case []interface{}:
+			cleanSliceRecursive(val)
+			if len(val) == 0 {
+				delete(m, k)
+			}
+		case string:
+			if val == "" || val == "null" {
+				delete(m, k)
+			}
+		}
+	}
+}
+
+// cleanSliceRecursive removes all null values recursively from a slice
+func cleanSliceRecursive(s []interface{}) {
+	for i, v := range s {
+		if v == nil {
+			s[i] = nil
+			continue
+		}
+
+		switch val := v.(type) {
+		case map[string]interface{}:
+			cleanMapRecursive(val)
+		case []interface{}:
+			cleanSliceRecursive(val)
+		}
+	}
+}
+
+// extractLocalWorkflows reads local workflow files and returns a map of workflow IDs to file paths
+func extractLocalWorkflows(directory string) (map[string]string, error) {
+	localFiles := make(map[string]string)
+
+	files, err := os.ReadDir(directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return localFiles, nil
+		}
+		return nil, fmt.Errorf("error reading directory: %w", err)
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		ext := strings.ToLower(filepath.Ext(file.Name()))
+		if ext != ".json" && ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		filePath := filepath.Join(directory, file.Name())
+		workflowID, err := ExtractWorkflowIDFromFile(filePath)
+		if err != nil || workflowID == "" {
+			continue
+		}
+
+		localFiles[workflowID] = filePath
+	}
+
+	return localFiles, nil
+}
+
+// determineFilePathAndAction decides what file path and action to take for a workflow
+func determineFilePathAndAction(workflow n8n.Workflow, localFiles map[string]string, directory string, output string, overwrite bool) (string, string) {
+	sanitizedName := rootcmd.SanitizeFilename(workflow.Name)
+	extension := ".json"
+	if strings.ToLower(output) == "yaml" || strings.ToLower(output) == "yml" {
+		extension = ".yaml"
+	}
+
+	defaultPath := filepath.Join(directory, sanitizedName+extension)
+
+	existingPath, exists := localFiles[*workflow.Id]
+	if !exists || overwrite {
+		return defaultPath, "Creating"
+	}
+
+	existingExt := filepath.Ext(existingPath)
+	if (strings.ToLower(output) == "yaml" || strings.ToLower(output) == "yml") && strings.ToLower(existingExt) == ".json" {
+		return defaultPath, "Converting"
+	}
+
+	if strings.ToLower(output) == "json" && (strings.ToLower(existingExt) == ".yaml" || strings.ToLower(existingExt) == ".yml") {
+		return defaultPath, "Converting"
+	}
+
+	return existingPath, "Updating"
+}
+
+// serializeWorkflow serializes a workflow to JSON or YAML
+func serializeWorkflow(workflow n8n.Workflow, filePath string, minimal bool) ([]byte, error) {
+	var workflowToSerialize interface{} = workflow
+	if minimal {
+		workflowToSerialize = cleanWorkflow(workflow)
+	}
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+	if ext == ".yaml" || ext == ".yml" {
+		var buf strings.Builder
+		buf.WriteString("---\n")
+		encoder := yaml.NewEncoder(&buf)
+		encoder.SetIndent(2)
+		if err := encoder.Encode(workflowToSerialize); err != nil {
+			return nil, fmt.Errorf("error serializing workflow '%s' to YAML: %w", workflow.Name, err)
+		}
+		return []byte(buf.String()), nil
+	}
+
+	content, err := json.MarshalIndent(workflowToSerialize, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("error serializing workflow '%s' to JSON: %w", workflow.Name, err)
+	}
+
+	return content, nil
+}
+
+// workflowNeedsUpdate compares existing workflow file content with new content
+func workflowNeedsUpdate(filePath string, existingPath string, content []byte, minimal bool) bool {
+	if _, fileErr := os.Stat(filePath); fileErr != nil {
+		return true
+	}
+
+	if !strings.EqualFold(filepath.Ext(existingPath), filepath.Ext(filePath)) {
+		return true
+	}
+
+	existingContent, readErr := os.ReadFile(filePath)
+	if readErr != nil {
+		return true
+	}
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+	if ext == ".yaml" || ext == ".yml" {
+		return compareYAMLContent(existingContent, content, minimal)
+	}
+
+	if minimal {
+		return compareJSONContent(existingContent, content)
+	}
+
+	return string(existingContent) != string(content)
+}
+
+// compareYAMLContent compares two YAML contents
+func compareYAMLContent(existingContent, newContent []byte, minimal bool) bool {
+	existingContentStr := string(existingContent)
+	if strings.HasPrefix(existingContentStr, "---\n") {
+		existingContent = []byte(strings.TrimPrefix(existingContentStr, "---\n"))
+	}
+
+	newContentStr := string(newContent)
+	if strings.HasPrefix(newContentStr, "---\n") {
+		newContent = []byte(strings.TrimPrefix(newContentStr, "---\n"))
+	}
+
+	var existingWorkflow, newWorkflow n8n.Workflow
+	if yamlErr := yaml.Unmarshal(existingContent, &existingWorkflow); yamlErr != nil {
+		return true
+	}
+
+	if yamlErr := yaml.Unmarshal(newContent, &newWorkflow); yamlErr != nil {
+		return true
+	}
+
+	var existingJSON, newJSON []byte
+	var err error
+
+	if minimal {
+		existingClean := cleanWorkflow(existingWorkflow)
+		newClean := cleanWorkflow(newWorkflow)
+		existingJSON, err = json.Marshal(existingClean)
+		if err != nil {
+			return true
+		}
+		newJSON, err = json.Marshal(newClean)
+		if err != nil {
+			return true
+		}
+	} else {
+		existingJSON, err = json.Marshal(existingWorkflow)
+		if err != nil {
+			return true
+		}
+		newJSON, err = json.Marshal(newWorkflow)
+		if err != nil {
+			return true
+		}
+	}
+
+	return string(existingJSON) != string(newJSON)
+}
+
+// compareJSONContent compares two JSON contents
+func compareJSONContent(existingContent, newContent []byte) bool {
+	var existingWorkflow, newWorkflow n8n.Workflow
+	if jsonErr := json.Unmarshal(existingContent, &existingWorkflow); jsonErr != nil {
+		return true
+	}
+
+	if jsonErr := json.Unmarshal(newContent, &newWorkflow); jsonErr != nil {
+		return true
+	}
+
+	existingClean := cleanWorkflow(existingWorkflow)
+	newClean := cleanWorkflow(newWorkflow)
+	existingJSON, err := json.Marshal(existingClean)
+	if err != nil {
+		return true
+	}
+
+	newJSON, err := json.Marshal(newClean)
+	if err != nil {
+		return true
+	}
+
+	return string(existingJSON) != string(newJSON)
+}
+
+// processWorkflow handles processing of a single workflow
+func processWorkflow(cmd *cobra.Command, workflow n8n.Workflow, localFiles map[string]string,
+	directory string, dryRun bool, overwrite bool, output string, minimal bool) error {
+
+	if workflow.Id == nil || *workflow.Id == "" {
+		cmd.Printf("Skipping workflow '%s' with no ID\n", workflow.Name)
+		return nil
+	}
+
+	filePath, action := determineFilePathAndAction(workflow, localFiles, directory, output, overwrite)
+	existingPath := localFiles[*workflow.Id]
+
+	content, err := serializeWorkflow(workflow, filePath, minimal)
+	if err != nil {
+		return err
+	}
+
+	needsUpdate := true
+	if action == "Updating" {
+		needsUpdate = workflowNeedsUpdate(filePath, existingPath, content, minimal)
+		if !needsUpdate {
+			cmd.Printf("No changes for workflow '%s' (ID: %s) in file: %s\n",
+				workflow.Name, *workflow.Id, filePath)
+			return nil
+		}
+	}
+
+	if dryRun {
+		if needsUpdate || action == "Creating" || action == "Converting" {
+			cmd.Printf("Would %s workflow '%s' (ID: %s) to file: %s\n",
+				strings.ToLower(action), workflow.Name, *workflow.Id, filePath)
+		} else {
+			cmd.Printf("No changes needed for workflow '%s' (ID: %s) in file: %s\n",
+				workflow.Name, *workflow.Id, filePath)
+		}
+		return nil
+	}
+
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		return fmt.Errorf("error writing workflow '%s' to file: %w", workflow.Name, err)
+	}
+
+	cmd.Printf("%s workflow '%s' (ID: %s) to file: %s\n",
+		action, workflow.Name, *workflow.Id, filePath)
+
 	return nil
 }

--- a/cmd/workflows/refresh.go
+++ b/cmd/workflows/refresh.go
@@ -179,7 +179,7 @@ func RefreshWorkflowsWithClient(cmd *cobra.Command, client n8n.ClientInterface, 
 
 		needsUpdate := true
 		if existingPath, exists := localFiles[*workflow.Id]; exists &&
-			strings.ToLower(filepath.Ext(existingPath)) == strings.ToLower(filepath.Ext(filePath)) {
+			strings.EqualFold(filepath.Ext(existingPath), filepath.Ext(filePath)) {
 			if _, fileErr := os.Stat(filePath); fileErr == nil {
 				existingContent, readErr := os.ReadFile(filePath)
 				if readErr == nil {

--- a/tests/unit/helpers.go
+++ b/tests/unit/helpers.go
@@ -1,10 +1,19 @@
 // Package unit contains unit tests for the n8n-cli
 package unit
 
+import (
+	"time"
+)
+
 func stringPtr(s string) *string {
 	return &s
 }
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func timePtr(s string) *time.Time {
+	t, _ := time.Parse(time.RFC3339, s)
+	return &t
 }

--- a/tests/unit/workflows_refresh_test.go
+++ b/tests/unit/workflows_refresh_test.go
@@ -208,7 +208,7 @@ func TestRefreshCommand(t *testing.T) {
 						continue
 					}
 
-					files, err := os.ReadDir(directory) // Use the directory from the test case
+					files, err := os.ReadDir(directory)
 					require.NoError(t, err)
 
 					found := false

--- a/tests/unit/workflows_refresh_test.go
+++ b/tests/unit/workflows_refresh_test.go
@@ -3,6 +3,7 @@ package unit
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRefreshCommand(t *testing.T) {
@@ -27,9 +29,10 @@ func TestRefreshCommand(t *testing.T) {
 		mockError      error
 		expectedOutput string
 		expectError    bool
+		setupFiles     func(t *testing.T, dir string)
 	}{
 		{
-			name: "Successfully refreshes workflows",
+			name: "Successfully refreshes workflows (JSON format)",
 			args: []string{"--directory", tempDir},
 			mockResponses: &n8n.WorkflowList{
 				Data: &[]n8n.Workflow{
@@ -48,6 +51,81 @@ func TestRefreshCommand(t *testing.T) {
 			mockError:      nil,
 			expectedOutput: "Creating workflow 'Test Workflow 1'",
 			expectError:    false,
+		},
+		{
+			name: "Successfully refreshes workflows (YAML format)",
+			args: []string{"--directory", tempDir, "--output", "yaml"},
+			mockResponses: &n8n.WorkflowList{
+				Data: &[]n8n.Workflow{
+					{
+						Id:     stringPtr("789"),
+						Name:   "Test Workflow 3",
+						Active: boolPtr(true),
+					},
+					{
+						Id:     stringPtr("abc"),
+						Name:   "Test Workflow 4",
+						Active: boolPtr(false),
+					},
+				},
+			},
+			mockError:      nil,
+			expectedOutput: "Creating workflow 'Test Workflow 3'",
+			expectError:    false,
+		},
+		{
+			name: "Detects no changes when content is identical (JSON)",
+			args: []string{"--directory", tempDir},
+			mockResponses: &n8n.WorkflowList{
+				Data: &[]n8n.Workflow{
+					{
+						Id:     stringPtr("123"),
+						Name:   "Test Workflow 1",
+						Active: boolPtr(true),
+					},
+				},
+			},
+			mockError:      nil,
+			expectedOutput: "No changes for workflow",
+			expectError:    false,
+			setupFiles: func(t *testing.T, dir string) {
+				workflow := n8n.Workflow{
+					Id:     stringPtr("123"),
+					Name:   "Test Workflow 1",
+					Active: boolPtr(true),
+				}
+				content, err := json.MarshalIndent(workflow, "", "  ")
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Join(dir, "Test_Workflow_1.json"), content, 0644)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Detects no changes when content is identical (YAML)",
+			args: []string{"--directory", tempDir, "--output", "yaml"},
+			mockResponses: &n8n.WorkflowList{
+				Data: &[]n8n.Workflow{
+					{
+						Id:     stringPtr("789"),
+						Name:   "Test Workflow 3",
+						Active: boolPtr(true),
+					},
+				},
+			},
+			mockError:      nil,
+			expectedOutput: "No changes for workflow",
+			expectError:    false,
+			setupFiles: func(t *testing.T, dir string) {
+				workflow := n8n.Workflow{
+					Id:     stringPtr("789"),
+					Name:   "Test Workflow 3",
+					Active: boolPtr(true),
+				}
+				content, err := yaml.Marshal(workflow)
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Join(dir, "Test_Workflow_3.yaml"), content, 0644)
+				require.NoError(t, err)
+			},
 		},
 		{
 			name:           "Returns error when API call fails",
@@ -69,6 +147,14 @@ func TestRefreshCommand(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			testDir := filepath.Join(tempDir, t.Name())
+			err := os.MkdirAll(testDir, 0755)
+			require.NoError(t, err)
+
+			if tc.setupFiles != nil {
+				tc.setupFiles(t, testDir)
+			}
+
 			fakeClient := &clientfakes.FakeClientInterface{}
 			fakeClient.GetWorkflowsReturns(tc.mockResponses, tc.mockError)
 
@@ -86,8 +172,19 @@ func TestRefreshCommand(t *testing.T) {
 			cmd.SetOut(outBuf)
 			cmd.SetErr(errBuf)
 
-			if err := cmd.Flags().Set("directory", tc.args[1]); err != nil {
+			if err := cmd.Flags().Set("directory", testDir); err != nil {
 				t.Fatal(err)
+			}
+
+			for i := 0; i < len(tc.args); i++ {
+				if tc.args[i] == "--output" || tc.args[i] == "-o" {
+					if i+1 < len(tc.args) {
+						if err := cmd.Flags().Set("output", tc.args[i+1]); err != nil {
+							t.Fatal(err)
+						}
+						break
+					}
+				}
 			}
 
 			directory, _ := cmd.Flags().GetString("directory")
@@ -95,7 +192,7 @@ func TestRefreshCommand(t *testing.T) {
 			overwrite, _ := cmd.Flags().GetBool("overwrite")
 			output, _ := cmd.Flags().GetString("output")
 
-			err := workflows.RefreshWorkflowsWithClient(cmd, fakeClient, directory, dryRun, overwrite, output)
+			err = workflows.RefreshWorkflowsWithClient(cmd, fakeClient, directory, dryRun, overwrite, output)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -111,13 +208,21 @@ func TestRefreshCommand(t *testing.T) {
 						continue
 					}
 
-					files, err := os.ReadDir(tempDir)
+					files, err := os.ReadDir(directory) // Use the directory from the test case
 					require.NoError(t, err)
 
 					found := false
+					expectedExt := ".json"
+					if cmd.Flags().Changed("output") {
+						outputFormat, _ := cmd.Flags().GetString("output")
+						if outputFormat == "yaml" || outputFormat == "yml" {
+							expectedExt = ".yaml"
+						}
+					}
+
 					for _, file := range files {
-						if !file.IsDir() && filepath.Ext(file.Name()) == ".json" {
-							filePath := filepath.Join(tempDir, file.Name())
+						if !file.IsDir() && (filepath.Ext(file.Name()) == expectedExt) {
+							filePath := filepath.Join(directory, file.Name())
 							content, err := os.ReadFile(filePath)
 							require.NoError(t, err)
 
@@ -128,7 +233,7 @@ func TestRefreshCommand(t *testing.T) {
 						}
 					}
 
-					require.True(t, found, "Workflow file should have been created")
+					require.True(t, found, "Workflow file should have been created with %s extension", expectedExt)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

This Pull Request provides a flag to the `workflows refresh` command allowing to get a cleaner output of the workflow file - removing all the unnecessary meta fields like createdAt, updatedAt, null fields etc..

It let you focus on the fields that matter.

### Changes

- **fix(build): Output binary to the bin directory**
- **fix(workflows): Enhance workflow refresh to support YAML output and detect no changes**
- **fix(workflows): Improve error handling and dry-run output in refresh command**
- **fix(workflows): Linting issue**
- **fix(workflows): Improve workflow refresh to handle YAML content comparison**
- **ai(docs): Improve Claude Instructions**
- **ai(docs): Update Copilot instructions for clarity and context**
- **fix(docs): Correct typo in Copilot instructions**
- **refactor(workflows): Add minimal flag to refresh command for cleaner output**
- **fix(workflows): Ensure connections field is initialized in cleanWorkflow and serializeWorkflow functions**
