### PR TITLE
feat(workflows-sync): Add --refresh flag to sync command and implement refresh functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Options:
 - `--dry-run`: Show what would be updated without making changes
 - `--overwrite`: Overwrite existing files even if they have a different name
 - `--output, -o`: Output format for new workflow files (json or yaml)
-- `--minimal`: Minimize workflow files by removing null and optional fields (default: true)
+- `--no-truncate`: Include all fields in output files, including null and optional fields (default: false)
 - `--all`: Refresh all workflows from n8n instance, not just those in the directory.
 
 Examples:
@@ -171,7 +171,7 @@ n8n workflows refresh --directory workflows/ --dry-run
 n8n workflows refresh --directory workflows/ --output yaml
 
 # Refresh workflows without minimizing the JSON/YAML output
-n8n workflows refresh --directory workflows/ --minimal=false
+n8n workflows refresh --directory workflows/ --no-truncate
 ```
 
 #### Sync

--- a/README.md
+++ b/README.md
@@ -152,13 +152,17 @@ Options:
 - `--dry-run`: Show what would be updated without making changes
 - `--overwrite`: Overwrite existing files even if they have a different name
 - `--output, -o`: Output format for new workflow files (json or yaml)
-- `--minimal`: Minimize workflow files by removing null and optional fields (default: true).
+- `--minimal`: Minimize workflow files by removing null and optional fields (default: true)
+- `--all`: Refresh all workflows from n8n instance, not just those in the directory.
 
-Example:
+Examples:
 
 ```bash
-# Refresh all workflows to local files
+# Refresh only existing workflows in the directory
 n8n workflows refresh --directory workflows/
+
+# Refresh all workflows from n8n instance (including new ones)
+n8n workflows refresh --directory workflows/ --all
 
 # Preview what would be refreshed without making changes
 n8n workflows refresh --directory workflows/ --dry-run

--- a/cmd/workflows/list.go
+++ b/cmd/workflows/list.go
@@ -57,7 +57,6 @@ var ListCmd = &cobra.Command{
 
 func init() {
 	ListCmd.Flags().StringVarP(&outputFormat, "output", "o", formatTable, "Output format: table, json, or yaml")
-	// TODO - implement pretty print (without created at and updated at and all the metadata that is not required for the client DTO)
 	rootcmd.GetWorkflowsCmd().AddCommand(ListCmd)
 }
 

--- a/cmd/workflows/refresh.go
+++ b/cmd/workflows/refresh.go
@@ -242,9 +242,6 @@ func workflowNeedsUpdate(filePath string, existingPath string, content []byte, m
 	return rootcmd.DetectWorkflowDrift(existingWorkflow, newWorkflow, minimal)
 }
 
-// Both compareYAMLContent and compareJSONContent functions have been replaced
-// by the DetectWorkflowDrift utility function in the cmd package
-
 // processWorkflow handles processing of a single workflow
 func processWorkflow(cmd *cobra.Command, workflow n8n.Workflow, localFiles map[string]string,
 	directory string, dryRun bool, overwrite bool, output string, minimal bool) error {

--- a/cmd/workflows/refresh.go
+++ b/cmd/workflows/refresh.go
@@ -48,7 +48,7 @@ func init() {
 	refreshCmd.Flags().Bool("dry-run", false, "Show what would be updated without making changes")
 	refreshCmd.Flags().Bool("overwrite", false, "Overwrite existing files even if they have a different name")
 	refreshCmd.Flags().StringP("output", "o", "json", "Output format for new workflow files (json or yaml)")
-	refreshCmd.Flags().Bool("minimal", true, "Minimize workflow files by removing null and optional fields")
+	refreshCmd.Flags().Bool("no-truncate", false, "Include all fields in output files, including null and optional fields")
 	refreshCmd.Flags().Bool("all", false, "Refresh all workflows from n8n instance, not just those in the directory")
 	rootcmd.GetWorkflowsCmd().AddCommand(refreshCmd)
 
@@ -63,7 +63,7 @@ func RefreshWorkflows(cmd *cobra.Command, args []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	overwrite, _ := cmd.Flags().GetBool("overwrite")
 	output, _ := cmd.Flags().GetString("output")
-	minimal, _ := cmd.Flags().GetBool("minimal")
+	noTruncate, _ := cmd.Flags().GetBool("no-truncate")
 	all, _ := cmd.Flags().GetBool("all")
 
 	if directory == "" {
@@ -74,6 +74,9 @@ func RefreshWorkflows(cmd *cobra.Command, args []string) error {
 	instanceURL := viper.Get("instance_url").(string)
 
 	client := n8n.NewClient(instanceURL, apiKey)
+
+	// Invert noTruncate flag to maintain backwards compatibility with the former minimal flag
+	minimal := !noTruncate
 
 	return RefreshWorkflowsWithClient(cmd, client, directory, dryRun, overwrite, output, minimal, all)
 }

--- a/cmd/workflows/sync.go
+++ b/cmd/workflows/sync.go
@@ -166,7 +166,8 @@ func SyncWorkflows(cmd *cobra.Command, args []string) error {
 	if refresh && !dryRun && len(updatedWorkflows) > 0 {
 		cmd.Println("Refreshing local workflow files with remote state...")
 
-		minimal := true
+		noTruncate := false
+		minimal := !noTruncate
 		overwrite := true
 
 		if err := RefreshWorkflowsWithClient(cmd, client, directory, false, overwrite, "", minimal, true); err != nil {

--- a/cmd/workflows/sync.go
+++ b/cmd/workflows/sync.go
@@ -169,7 +169,7 @@ func SyncWorkflows(cmd *cobra.Command, args []string) error {
 		minimal := true
 		overwrite := true
 
-		if err := RefreshWorkflowsWithClient(cmd, client, directory, false, overwrite, "", minimal); err != nil {
+		if err := RefreshWorkflowsWithClient(cmd, client, directory, false, overwrite, "", minimal, true); err != nil {
 			return fmt.Errorf("error refreshing workflows after sync: %w", err)
 		}
 

--- a/examples/contact-form-ai/Taskfile.yaml
+++ b/examples/contact-form-ai/Taskfile.yaml
@@ -31,6 +31,12 @@ tasks:
       - echo "Refreshing workflows from n8n instance..."
       - n8n workflows refresh --directory {{.WORKFLOW_DIR}}/ --output yaml
 
+  refresh-all:
+    desc: Refresh all workflows from n8n instance (including new ones)
+    cmds:
+      - echo "Refreshing all workflows from n8n instance..."
+      - n8n workflows refresh --directory {{.WORKFLOW_DIR}}/ --output yaml --all
+
   list:
     desc: List workflows from n8n instance
     cmds:

--- a/examples/contact-form/Taskfile.yaml
+++ b/examples/contact-form/Taskfile.yaml
@@ -25,6 +25,12 @@ tasks:
       - echo "Refreshing workflows from n8n instance..."
       - n8n workflows refresh --directory {{.WORKFLOW_DIR}}/ --output yaml
 
+  refresh-all:
+    desc: Refresh all workflows from n8n instance (including new ones)
+    cmds:
+      - echo "Refreshing all workflows from n8n instance..."
+      - n8n workflows refresh --directory {{.WORKFLOW_DIR}}/ --output yaml --all
+
   list:
     desc: List workflows from n8n instance
     cmds:

--- a/tests/integration/workflows_sync_refresh_test.go
+++ b/tests/integration/workflows_sync_refresh_test.go
@@ -1,0 +1,275 @@
+// filepath: /workspaces/n8n-cli/tests/integration/workflows_sync_refresh_test.go
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/edenreich/n8n-cli/cmd/workflows"
+	"github.com/edenreich/n8n-cli/n8n"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncWorkflows_Refresh(t *testing.T) {
+	testCases := []struct {
+		name           string
+		refreshFlag    bool
+		expectIDInFile bool
+		args           []string
+	}{
+		{
+			name:           "Default behavior (refresh=true)",
+			refreshFlag:    true,
+			expectIDInFile: true,
+			args:           []string{"--directory"},
+		},
+		{
+			name:           "Explicit refresh=false",
+			refreshFlag:    false,
+			expectIDInFile: false,
+			args:           []string{"--directory", "", "--refresh=false"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "workflow-sync-refresh-test")
+			require.NoError(t, err)
+			defer func() {
+				if err := os.RemoveAll(tmpDir); err != nil {
+					t.Fatalf("Failed to remove temp directory: %v", err)
+				}
+			}()
+
+			noIDWorkflow := n8n.Workflow{
+				Name:        "New Workflow",
+				Nodes:       []n8n.Node{},
+				Connections: map[string]interface{}{},
+				Settings:    n8n.WorkflowSettings{},
+			}
+			inactive := false
+			noIDWorkflow.Active = &inactive
+
+			noIDWorkflowBytes, err := json.MarshalIndent(noIDWorkflow, "", "  ")
+			require.NoError(t, err)
+
+			noIDFilePath := filepath.Join(tmpDir, "new_workflow.json")
+			require.NoError(t, os.WriteFile(noIDFilePath, noIDWorkflowBytes, 0644))
+
+			nonexistentID := "nonexistent-id"
+			nonExistentWorkflow := n8n.Workflow{
+				Id:          &nonexistentID,
+				Name:        "Nonexistent ID Workflow",
+				Nodes:       []n8n.Node{},
+				Connections: map[string]interface{}{},
+				Settings:    n8n.WorkflowSettings{},
+			}
+			nonExistentWorkflow.Active = &inactive
+
+			nonExistentWorkflowBytes, err := json.MarshalIndent(nonExistentWorkflow, "", "  ")
+			require.NoError(t, err)
+
+			nonexistentIDFilePath := filepath.Join(tmpDir, "nonexistent_id_workflow.json")
+			require.NoError(t, os.WriteFile(nonexistentIDFilePath, nonExistentWorkflowBytes, 0644))
+
+			var requestCounter int
+			var createdWorkflows []n8n.Workflow
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Printf("Request %d: %s %s\n", requestCounter, r.Method, r.URL.Path)
+				requestCounter++
+
+				if r.Header.Get("X-N8N-API-KEY") != "test-api-key" {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = fmt.Fprintln(w, `{"error": "Unauthorized"}`)
+					return
+				}
+
+				switch {
+				case r.URL.Path == "/api/v1/workflows" && r.Method == http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					response := n8n.WorkflowList{
+						Data: &createdWorkflows,
+					}
+					_ = json.NewEncoder(w).Encode(response)
+
+				case r.URL.Path == "/api/v1/workflows" && r.Method == http.MethodPost:
+					var workflow n8n.Workflow
+					err := json.NewDecoder(r.Body).Decode(&workflow)
+					if err != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						_, _ = fmt.Fprintln(w, `{"error": "Invalid workflow data"}`)
+						return
+					}
+
+					newID := fmt.Sprintf("generated-id-%d", len(createdWorkflows)+1)
+					workflow.Id = &newID
+
+					createdWorkflows = append(createdWorkflows, workflow)
+
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(workflow)
+
+				case strings.HasSuffix(r.URL.Path, "/activate") && r.Method == http.MethodPost:
+
+					id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/workflows/"), "/activate")
+
+					var foundWorkflow *n8n.Workflow
+					for i := range createdWorkflows {
+						if createdWorkflows[i].Id != nil && *createdWorkflows[i].Id == id {
+							foundWorkflow = &createdWorkflows[i]
+							active := true
+							foundWorkflow.Active = &active
+							break
+						}
+					}
+
+					if foundWorkflow != nil {
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(foundWorkflow)
+					} else {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = fmt.Fprintf(w, `{"error": "Workflow with ID %s not found"}`, id)
+					}
+					return
+
+				case strings.HasSuffix(r.URL.Path, "/deactivate") && r.Method == http.MethodPost:
+					id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/workflows/"), "/deactivate")
+
+					var foundWorkflow *n8n.Workflow
+					for i := range createdWorkflows {
+						if createdWorkflows[i].Id != nil && *createdWorkflows[i].Id == id {
+							foundWorkflow = &createdWorkflows[i]
+							inactive := false
+							foundWorkflow.Active = &inactive
+							break
+						}
+					}
+
+					if foundWorkflow != nil {
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(foundWorkflow)
+					} else {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = fmt.Fprintf(w, `{"error": "Workflow with ID %s not found"}`, id)
+					}
+					return
+
+				case strings.HasPrefix(r.URL.Path, "/api/v1/workflows/") && r.Method == http.MethodGet:
+					id := strings.TrimPrefix(r.URL.Path, "/api/v1/workflows/")
+
+					for i := range createdWorkflows {
+						if createdWorkflows[i].Id != nil && *createdWorkflows[i].Id == id {
+							w.Header().Set("Content-Type", "application/json")
+							_ = json.NewEncoder(w).Encode(createdWorkflows[i])
+							return
+						}
+					}
+
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = fmt.Fprintf(w, `{"error": "Workflow with ID %s not found"}`, id)
+
+				case strings.HasPrefix(r.URL.Path, "/api/v1/workflows/") && r.Method == http.MethodPut:
+					id := strings.TrimPrefix(r.URL.Path, "/api/v1/workflows/")
+
+					var workflow n8n.Workflow
+					err := json.NewDecoder(r.Body).Decode(&workflow)
+					if err != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						_, _ = fmt.Fprintln(w, `{"error": "Invalid workflow data"}`)
+						return
+					}
+
+					found := false
+					for i := range createdWorkflows {
+						if createdWorkflows[i].Id != nil && *createdWorkflows[i].Id == id {
+							workflow.Id = &id
+							createdWorkflows[i] = workflow
+							found = true
+							break
+						}
+					}
+
+					if !found {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = fmt.Fprintf(w, `{"error": "Workflow with ID %s not found"}`, id)
+						return
+					}
+
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(workflow)
+				}
+			}))
+			defer server.Close()
+
+			viper.Set("api_key", "test-api-key")
+			viper.Set("instance_url", server.URL)
+			defer viper.Reset()
+
+			var args []string
+			if tc.refreshFlag {
+				args = []string{"--directory", tmpDir}
+			} else {
+				args = []string{"--directory", tmpDir, "--refresh=false"}
+			}
+
+			stdout, stderr, err := executeCommand(t, workflows.SyncCmd, args...)
+			assert.NoError(t, err, "Command should succeed: %s\nstderr: %s", stdout, stderr)
+
+			if !tc.expectIDInFile {
+				content, err := os.ReadFile(noIDFilePath)
+				require.NoError(t, err)
+
+				var workflow n8n.Workflow
+				err = json.Unmarshal(content, &workflow)
+				require.NoError(t, err)
+
+				assert.Nil(t, workflow.Id, "With refresh=false, the file should not have been updated with an ID")
+
+				content, err = os.ReadFile(nonexistentIDFilePath)
+				require.NoError(t, err)
+
+				workflow = n8n.Workflow{}
+				err = json.Unmarshal(content, &workflow)
+				require.NoError(t, err)
+
+				assert.NotNil(t, workflow.Id, "ID field should exist")
+				assert.Equal(t, "nonexistent-id", *workflow.Id, "With refresh=false, the file should retain its original ID")
+			} else {
+				files, err := os.ReadDir(tmpDir)
+				require.NoError(t, err)
+
+				idUpdated := false
+
+				for _, file := range files {
+					if file.IsDir() {
+						continue
+					}
+
+					filePath := filepath.Join(tmpDir, file.Name())
+					content, err := os.ReadFile(filePath)
+					require.NoError(t, err)
+
+					var workflow n8n.Workflow
+					err = json.Unmarshal(content, &workflow)
+					require.NoError(t, err)
+
+					if workflow.Id != nil && strings.HasPrefix(*workflow.Id, "generated-id-") {
+						idUpdated = true
+						break
+					}
+				}
+
+				assert.True(t, idUpdated, "Expected at least one workflow file to be updated with a new ID")
+			}
+		})
+	}
+}

--- a/tests/unit/workflows_refresh_test.go
+++ b/tests/unit/workflows_refresh_test.go
@@ -440,7 +440,7 @@ active: true
 			cmd.Flags().Bool("dry-run", false, "Dry run")
 			cmd.Flags().Bool("overwrite", false, "Overwrite")
 			cmd.Flags().StringP("output", "o", "json", "Output format")
-			cmd.Flags().Bool("minimal", true, "Minimal output")
+			cmd.Flags().Bool("no-truncate", false, "Include all fields in output")
 			cmd.Flags().Bool("all", false, "Refresh all workflows")
 			cmd.SetOut(outBuf)
 			cmd.SetErr(errBuf)
@@ -464,7 +464,8 @@ active: true
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			overwrite, _ := cmd.Flags().GetBool("overwrite")
 			output, _ := cmd.Flags().GetString("output")
-			minimal, _ := cmd.Flags().GetBool("minimal")
+			noTruncate, _ := cmd.Flags().GetBool("no-truncate")
+			minimal := !noTruncate
 
 			all := false
 			for i := 0; i < len(tc.args); i++ {

--- a/tests/unit/workflows_refresh_test.go
+++ b/tests/unit/workflows_refresh_test.go
@@ -231,6 +231,164 @@ active: true
 				assert.False(t, hasUpdatedAt, "updatedAt should be excluded from the workflow")
 			},
 		},
+		{
+			name: "Only refreshes existing workflows when --all is not specified",
+			args: []string{"--directory", tempDir},
+			mockResponses: &n8n.WorkflowList{
+				Data: &[]n8n.Workflow{
+					{
+						Id:     stringPtr("existing123"),
+						Name:   "Existing Workflow",
+						Active: boolPtr(true),
+					},
+					{
+						Id:     stringPtr("nonexisting456"),
+						Name:   "Non-Existing Workflow",
+						Active: boolPtr(false),
+					},
+				},
+			},
+			mockError:      nil,
+			expectedOutput: "Refreshing only workflows that exist in the directory",
+			expectError:    false,
+			setupFiles: func(t *testing.T, dir string) {
+				// Create a file for the "existing123" workflow
+				filePath := filepath.Join(dir, "Existing_Workflow.json")
+				workflow := n8n.Workflow{
+					Id:     stringPtr("existing123"),
+					Name:   "Existing Workflow",
+					Active: boolPtr(false), // We'll set it to false so we can detect the update
+				}
+
+				encoder := n8n.NewWorkflowEncoder(true)
+				content, err := encoder.EncodeToJSON(workflow)
+				require.NoError(t, err)
+
+				err = os.WriteFile(filePath, content, 0644)
+				require.NoError(t, err)
+			},
+			validateFiles: func(t *testing.T, dir string) {
+				// The existing workflow should be updated
+				existingPath := filepath.Join(dir, "Existing_Workflow.json")
+				content, err := os.ReadFile(existingPath)
+				require.NoError(t, err)
+
+				var workflow map[string]interface{}
+				err = json.Unmarshal(content, &workflow)
+				require.NoError(t, err)
+
+				assert.Equal(t, true, workflow["active"], "Existing workflow should be updated to active=true")
+
+				// The non-existing workflow should not be created
+				nonExistingPath := filepath.Join(dir, "Non-Existing_Workflow.json")
+				_, err = os.Stat(nonExistingPath)
+				assert.True(t, os.IsNotExist(err), "Non-existing workflow should not be created without --all flag")
+			},
+		},
+		{
+			name: "Refreshes all workflows when --all flag is specified",
+			args: []string{"--directory", tempDir, "--all"},
+			mockResponses: &n8n.WorkflowList{
+				Data: &[]n8n.Workflow{
+					{
+						Id:     stringPtr("existing123"),
+						Name:   "Existing Workflow",
+						Active: boolPtr(true),
+					},
+					{
+						Id:     stringPtr("nonexisting456"),
+						Name:   "Non-Existing Workflow",
+						Active: boolPtr(true),
+					},
+				},
+			},
+			mockError:      nil,
+			expectedOutput: "Refreshing all workflows from n8n instance",
+			expectError:    false,
+			setupFiles: func(t *testing.T, dir string) {
+				filePath := filepath.Join(dir, "Existing_Workflow.json")
+				workflow := n8n.Workflow{
+					Id:     stringPtr("existing123"),
+					Name:   "Existing Workflow",
+					Active: boolPtr(false),
+				}
+
+				encoder := n8n.NewWorkflowEncoder(true)
+				content, err := encoder.EncodeToJSON(workflow)
+				require.NoError(t, err)
+
+				err = os.WriteFile(filePath, content, 0644)
+				require.NoError(t, err)
+			},
+			validateFiles: func(t *testing.T, dir string) {
+				existingPath := filepath.Join(dir, "Existing_Workflow.json")
+				content, err := os.ReadFile(existingPath)
+				require.NoError(t, err)
+
+				var workflow map[string]interface{}
+				err = json.Unmarshal(content, &workflow)
+				require.NoError(t, err)
+
+				assert.Equal(t, true, workflow["active"], "Existing workflow should be updated to active=true")
+
+				nonExistingPath := filepath.Join(dir, "Non-Existing_Workflow.json")
+				content, err = os.ReadFile(nonExistingPath)
+				require.NoError(t, err)
+
+				err = json.Unmarshal(content, &workflow)
+				require.NoError(t, err)
+
+				assert.Equal(t, "nonexisting456", workflow["id"], "Non-existing workflow should be created with --all flag")
+				assert.Equal(t, true, workflow["active"], "Non-existing workflow should have active=true")
+			},
+		},
+		{
+			name:           "Handles errors when fetching individual workflows",
+			args:           []string{"--directory", tempDir},
+			mockResponses:  nil,
+			mockError:      nil,
+			expectedOutput: "Warning: Could not fetch workflow with ID",
+			expectError:    false,
+			setupFiles: func(t *testing.T, dir string) {
+				filePath := filepath.Join(dir, "Error_Workflow.json")
+				workflow := n8n.Workflow{
+					Id:     stringPtr("error123"),
+					Name:   "Error Workflow",
+					Active: boolPtr(false),
+				}
+
+				encoder := n8n.NewWorkflowEncoder(true)
+				content, err := encoder.EncodeToJSON(workflow)
+				require.NoError(t, err)
+
+				err = os.WriteFile(filePath, content, 0644)
+				require.NoError(t, err)
+
+				successPath := filepath.Join(dir, "Success_Workflow.json")
+				successWorkflow := n8n.Workflow{
+					Id:     stringPtr("success456"),
+					Name:   "Success Workflow",
+					Active: boolPtr(false),
+				}
+
+				content, err = encoder.EncodeToJSON(successWorkflow)
+				require.NoError(t, err)
+
+				err = os.WriteFile(successPath, content, 0644)
+				require.NoError(t, err)
+			},
+			validateFiles: func(t *testing.T, dir string) {
+				successPath := filepath.Join(dir, "Success_Workflow.json")
+				content, err := os.ReadFile(successPath)
+				require.NoError(t, err)
+
+				var workflow map[string]interface{}
+				err = json.Unmarshal(content, &workflow)
+				require.NoError(t, err)
+
+				assert.Equal(t, true, workflow["active"], "Success workflow should be updated to active=true")
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -246,6 +404,31 @@ active: true
 			fakeClient := &clientfakes.FakeClientInterface{}
 			fakeClient.GetWorkflowsReturns(tc.mockResponses, tc.mockError)
 
+			fakeClient.GetWorkflowCalls(func(id string) (*n8n.Workflow, error) {
+				if tc.name == "Handles errors when fetching individual workflows" {
+					switch id {
+					case "success456":
+						return &n8n.Workflow{
+							Id:     stringPtr("success456"),
+							Name:   "Success Workflow",
+							Active: boolPtr(true),
+						}, nil
+					case "error123":
+						return nil, errors.New("API error fetching workflow")
+					}
+				}
+
+				if tc.mockResponses != nil && tc.mockResponses.Data != nil {
+					for _, workflow := range *tc.mockResponses.Data {
+						if workflow.Id != nil && *workflow.Id == id {
+							return &workflow, nil
+						}
+					}
+				}
+
+				return nil, errors.New("workflow not found")
+			})
+
 			viper.Set("api_key", "test_api_key")
 			viper.Set("instance_url", "http://test.n8n.local")
 
@@ -258,6 +441,7 @@ active: true
 			cmd.Flags().Bool("overwrite", false, "Overwrite")
 			cmd.Flags().StringP("output", "o", "json", "Output format")
 			cmd.Flags().Bool("minimal", true, "Minimal output")
+			cmd.Flags().Bool("all", false, "Refresh all workflows")
 			cmd.SetOut(outBuf)
 			cmd.SetErr(errBuf)
 
@@ -282,7 +466,15 @@ active: true
 			output, _ := cmd.Flags().GetString("output")
 			minimal, _ := cmd.Flags().GetBool("minimal")
 
-			err = workflows.RefreshWorkflowsWithClient(cmd, fakeClient, directory, dryRun, overwrite, output, minimal)
+			all := false
+			for i := 0; i < len(tc.args); i++ {
+				if tc.args[i] == "--all" {
+					all = true
+					break
+				}
+			}
+
+			err = workflows.RefreshWorkflowsWithClient(cmd, fakeClient, directory, dryRun, overwrite, output, minimal, all)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/tests/unit/workflows_sync_refresh_test.go
+++ b/tests/unit/workflows_sync_refresh_test.go
@@ -1,0 +1,74 @@
+package unit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/edenreich/n8n-cli/cmd/workflows"
+	"github.com/edenreich/n8n-cli/n8n"
+	"github.com/edenreich/n8n-cli/n8n/clientfakes"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessWorkflowFile_ReturnsWorkflowResult(t *testing.T) {
+	fakeClient := &clientfakes.FakeClientInterface{}
+	cmd := &cobra.Command{}
+
+	tempDir, err := os.MkdirTemp("", "n8n-cli-test")
+	require.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(tempDir)
+		if err != nil {
+			t.Fatalf("Failed to remove temp directory: %v", err)
+		}
+	}()
+
+	testFilePath := filepath.Join(tempDir, "test-workflow.json")
+
+	workflowID := "test-id-123"
+	workflow := n8n.Workflow{
+		Name: "Test Workflow",
+		Id:   &workflowID,
+	}
+
+	fakeClient.GetWorkflowReturns(nil, fmt.Errorf("workflow not found"))
+
+	newID := "new-id-456"
+	fakeClient.CreateWorkflowReturns(&n8n.Workflow{
+		Id:   &newID,
+		Name: workflow.Name,
+	}, nil)
+
+	workflowJSON := `{"name": "Test Workflow", "id": "test-id-123"}`
+	err = os.WriteFile(testFilePath, []byte(workflowJSON), 0644)
+	require.NoError(t, err)
+
+	result, err := workflows.ProcessWorkflowFile(fakeClient, cmd, testFilePath, false, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, newID, result.WorkflowID)
+	assert.Equal(t, "Test Workflow", result.Name)
+	assert.Equal(t, testFilePath, result.FilePath)
+	assert.True(t, result.Created)
+	assert.False(t, result.Updated)
+}
+
+func TestWorkflowResult(t *testing.T) {
+	result := workflows.WorkflowResult{
+		WorkflowID: "123",
+		Name:       "Test Workflow",
+		FilePath:   "/path/to/file",
+		Created:    true,
+		Updated:    false,
+	}
+
+	assert.Equal(t, "123", result.WorkflowID)
+	assert.Equal(t, "Test Workflow", result.Name)
+	assert.Equal(t, "/path/to/file", result.FilePath)
+	assert.True(t, result.Created)
+	assert.False(t, result.Updated)
+}


### PR DESCRIPTION
## Summary

After syncing normally you also need to update the local state - this Pull Request provide a flag to the sync command to update the local state.
Default is true.
In some cases you might don't want to update the local state so it's optional and you could opt-out when setting it to false.
