### PR TITLE
refactor(sync): Use early return instead of nested if checks

### DIFF
--- a/examples/contact-form-ai/workflows/Contact_Form_AI.yaml
+++ b/examples/contact-form-ai/workflows/Contact_Form_AI.yaml
@@ -36,7 +36,7 @@ connections:
       - - index: 0
           node: Sample Data
           type: main
-id: 6kvfv4xdAFVYisbY
+id: y7dQE8rfF8tUxM7s
 name: Contact Form AI
 nodes:
   - id: 26476cd4-4435-4887-b419-ea2aaf703fd3


### PR DESCRIPTION
## Summary

Keep the code more maintainable by using early returns instead of nested if statements. This makes the code easier to read and understand, as it reduces the complexity of the control flow.
