### PR TITLE
fix(encoder): Strip StaticData in CleanWorkflow to prevent false sync diffs

### DIFF
--- a/n8n/encoder.go
+++ b/n8n/encoder.go
@@ -19,6 +19,7 @@ func CleanWorkflow(workflow Workflow) Workflow {
 	cleanedWorkflow.CreatedAt = nil
 	cleanedWorkflow.UpdatedAt = nil
 	cleanedWorkflow.Shared = nil
+	cleanedWorkflow.StaticData = nil
 
 	if cleanedWorkflow.Tags != nil && len(*cleanedWorkflow.Tags) > 0 {
 		cleanTags := make([]Tag, len(*cleanedWorkflow.Tags))

--- a/tests/unit/encoder_test.go
+++ b/tests/unit/encoder_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/edenreich/n8n-cli/n8n"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleanWorkflow(t *testing.T) {
@@ -21,12 +22,17 @@ func TestCleanWorkflow(t *testing.T) {
 		UpdatedAt:   updatedAt,
 	}
 
+	staticData := &n8n.Workflow_StaticData{}
+	err := staticData.UnmarshalJSON([]byte(`{"key":"value"}`))
+	require.NoError(t, err)
+
 	workflow := n8n.Workflow{
 		Name:        "Test Workflow",
 		Nodes:       []n8n.Node{node},
 		Connections: nil,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
+		StaticData:  staticData,
 	}
 
 	cleanedWorkflow := n8n.CleanWorkflow(workflow)
@@ -35,6 +41,7 @@ func TestCleanWorkflow(t *testing.T) {
 
 	assert.Nil(t, cleanedWorkflow.CreatedAt, "CreatedAt should be nil")
 	assert.Nil(t, cleanedWorkflow.UpdatedAt, "UpdatedAt should be nil")
+	assert.Nil(t, cleanedWorkflow.StaticData, "StaticData should be nil")
 
 	assert.NotNil(t, cleanedWorkflow.Connections, "Connections should be initialized")
 

--- a/tests/unit/workflows_sync_staticdata_test.go
+++ b/tests/unit/workflows_sync_staticdata_test.go
@@ -1,0 +1,44 @@
+package unit
+
+import (
+	"testing"
+
+	"github.com/edenreich/n8n-cli/cmd/workflows"
+	"github.com/edenreich/n8n-cli/n8n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectWorkflowChanges_StaticData(t *testing.T) {
+	compactBytes := []byte(`{"lastRun":1234567890,"counter":42}`)
+	indentedBytes := []byte("{\n  \"lastRun\": 1234567890,\n  \"counter\": 42\n}")
+
+	compactStaticData := &n8n.Workflow_StaticData{}
+	err := compactStaticData.UnmarshalJSON(compactBytes)
+	require.NoError(t, err)
+
+	indentedStaticData := &n8n.Workflow_StaticData{}
+	err = indentedStaticData.UnmarshalJSON(indentedBytes)
+	require.NoError(t, err)
+
+	remote := &n8n.Workflow{
+		Name:        "Test Workflow",
+		Id:          stringPtr("abc123"),
+		Active:      boolPtr(true),
+		StaticData:  compactStaticData,
+		Connections: make(map[string]interface{}),
+	}
+
+	local := &n8n.Workflow{
+		Name:        "Test Workflow",
+		Id:          stringPtr("abc123"),
+		Active:      boolPtr(true),
+		StaticData:  indentedStaticData,
+		Connections: make(map[string]interface{}),
+	}
+
+	changes := workflows.DetectWorkflowChanges(local, remote)
+
+	assert.False(t, changes.NeedsUpdate,
+		"NeedsUpdate should be false when only staticData byte formatting differs between local and remote")
+}


### PR DESCRIPTION
Fixes #35

## Summary

- Strip `StaticData` in `CleanWorkflow` so that both `sync` and `refresh` use the same normalised comparison
- `staticData` is runtime execution state, not workflow definition - it should not influence change detection or be synced from local files
- Fixes the inconsistency where compact API bytes vs indented file bytes caused `reflect.DeepEqual` to report false positives

## Test plan

- [x] `TestCleanWorkflow` updated to assert `StaticData` is stripped
- [x] New `TestDetectWorkflowChanges_StaticData` reproduces the exact bug scenario: compact API bytes vs indented file bytes no longer triggers a false update
- [x] Run `task test-unit` to verify all tests pass

Generated with [Claude Code](https://claude.ai/code)